### PR TITLE
feature: Calculate population needs periodically if desired

### DIFF
--- a/Warenrechner.Designer.cs
+++ b/Warenrechner.Designer.cs
@@ -96,6 +96,8 @@
             this.textBoxProcessName = new System.Windows.Forms.TextBox();
             this.checkBoxPeriodicCheck = new System.Windows.Forms.CheckBox();
             this.labelError = new System.Windows.Forms.Label();
+            this.textBoxPeriodicCheckInterval = new System.Windows.Forms.TextBox();
+            this.labelSeconds = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
@@ -781,20 +783,42 @@
             this.checkBoxPeriodicCheck.AutoSize = true;
             this.checkBoxPeriodicCheck.Location = new System.Drawing.Point(457, 129);
             this.checkBoxPeriodicCheck.Name = "checkBoxPeriodicCheck";
-            this.checkBoxPeriodicCheck.Size = new System.Drawing.Size(120, 17);
+            this.checkBoxPeriodicCheck.Size = new System.Drawing.Size(86, 17);
             this.checkBoxPeriodicCheck.TabIndex = 19;
-            this.checkBoxPeriodicCheck.Text = "Check every minute";
+            this.checkBoxPeriodicCheck.Text = "Check every";
             this.checkBoxPeriodicCheck.UseVisualStyleBackColor = true;
             this.checkBoxPeriodicCheck.CheckedChanged += new System.EventHandler(this.checkBoxPeriodicCheck_CheckedChanged);
             // 
             // labelError
             // 
             this.labelError.AutoSize = true;
-            this.labelError.Location = new System.Drawing.Point(601, 130);
+            this.labelError.ForeColor = System.Drawing.Color.Red;
+            this.labelError.Location = new System.Drawing.Point(643, 130);
             this.labelError.Name = "labelError";
             this.labelError.Size = new System.Drawing.Size(16, 13);
             this.labelError.TabIndex = 20;
             this.labelError.Text = "...";
+            // 
+            // textBoxPeriodicCheckInterval
+            // 
+            this.textBoxPeriodicCheckInterval.Enabled = false;
+            this.textBoxPeriodicCheckInterval.Location = new System.Drawing.Point(538, 127);
+            this.textBoxPeriodicCheckInterval.MaxLength = 5;
+            this.textBoxPeriodicCheckInterval.Name = "textBoxPeriodicCheckInterval";
+            this.textBoxPeriodicCheckInterval.Size = new System.Drawing.Size(35, 20);
+            this.textBoxPeriodicCheckInterval.TabIndex = 21;
+            this.textBoxPeriodicCheckInterval.Text = "60";
+            this.textBoxPeriodicCheckInterval.TextChanged += new System.EventHandler(this.textBoxPeriodicCheckInterval_TextChanged);
+            this.textBoxPeriodicCheckInterval.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxPeriodicCheckInterval_KeyPress);
+            // 
+            // labelSeconds
+            // 
+            this.labelSeconds.AutoSize = true;
+            this.labelSeconds.Location = new System.Drawing.Point(573, 130);
+            this.labelSeconds.Name = "labelSeconds";
+            this.labelSeconds.Size = new System.Drawing.Size(47, 13);
+            this.labelSeconds.TabIndex = 22;
+            this.labelSeconds.Text = "seconds";
             // 
             // Warenrechner
             // 
@@ -802,6 +826,8 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.ClientSize = new System.Drawing.Size(904, 182);
+            this.Controls.Add(this.labelSeconds);
+            this.Controls.Add(this.textBoxPeriodicCheckInterval);
             this.Controls.Add(this.labelError);
             this.Controls.Add(this.checkBoxPeriodicCheck);
             this.Controls.Add(this.textBoxProcessName);
@@ -949,6 +975,8 @@
         private System.Windows.Forms.TextBox textBoxProcessName;
         private System.Windows.Forms.CheckBox checkBoxPeriodicCheck;
         private System.Windows.Forms.Label labelError;
+        private System.Windows.Forms.TextBox textBoxPeriodicCheckInterval;
+        private System.Windows.Forms.Label labelSeconds;
     }
 }
 

--- a/Warenrechner.Designer.cs
+++ b/Warenrechner.Designer.cs
@@ -94,6 +94,8 @@
             this.buttonLoadNeeds = new System.Windows.Forms.Button();
             this.labelAnnoProcess = new System.Windows.Forms.Label();
             this.textBoxProcessName = new System.Windows.Forms.TextBox();
+            this.checkBoxPeriodicCheck = new System.Windows.Forms.CheckBox();
+            this.labelError = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
@@ -774,12 +776,34 @@
             this.textBoxProcessName.TabIndex = 18;
             this.textBoxProcessName.Text = "Addon.exe";
             // 
+            // checkBoxPeriodicCheck
+            // 
+            this.checkBoxPeriodicCheck.AutoSize = true;
+            this.checkBoxPeriodicCheck.Location = new System.Drawing.Point(457, 129);
+            this.checkBoxPeriodicCheck.Name = "checkBoxPeriodicCheck";
+            this.checkBoxPeriodicCheck.Size = new System.Drawing.Size(120, 17);
+            this.checkBoxPeriodicCheck.TabIndex = 19;
+            this.checkBoxPeriodicCheck.Text = "Check every minute";
+            this.checkBoxPeriodicCheck.UseVisualStyleBackColor = true;
+            this.checkBoxPeriodicCheck.CheckedChanged += new System.EventHandler(this.checkBoxPeriodicCheck_CheckedChanged);
+            // 
+            // labelError
+            // 
+            this.labelError.AutoSize = true;
+            this.labelError.Location = new System.Drawing.Point(601, 130);
+            this.labelError.Name = "labelError";
+            this.labelError.Size = new System.Drawing.Size(16, 13);
+            this.labelError.TabIndex = 20;
+            this.labelError.Text = "...";
+            // 
             // Warenrechner
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.ClientSize = new System.Drawing.Size(904, 182);
+            this.Controls.Add(this.labelError);
+            this.Controls.Add(this.checkBoxPeriodicCheck);
             this.Controls.Add(this.textBoxProcessName);
             this.Controls.Add(this.labelAnnoProcess);
             this.Controls.Add(this.buttonLoadNeeds);
@@ -923,6 +947,8 @@
         private System.Windows.Forms.Button buttonLoadNeeds;
         private System.Windows.Forms.Label labelAnnoProcess;
         private System.Windows.Forms.TextBox textBoxProcessName;
+        private System.Windows.Forms.CheckBox checkBoxPeriodicCheck;
+        private System.Windows.Forms.Label labelError;
     }
 }
 

--- a/Warenrechner.cs
+++ b/Warenrechner.cs
@@ -5,9 +5,20 @@ namespace Anno1404Warenrechner
 {
     public partial class Warenrechner : Form
     {
+        Timer periodicCheckTimer = new Timer();
         public Warenrechner()
         {
             InitializeComponent();
+            periodicCheckTimer.Interval = 60000;
+            periodicCheckTimer.Tick += PeriodicCheckTimer_Tick;
+
+            labelError.Text = "";
+            labelError.ForeColor = System.Drawing.Color.Red;
+        }
+
+        private void PeriodicCheckTimer_Tick(object sender, EventArgs e)
+        {
+            buttonLoadNeeds.PerformClick();
         }
 
         private void Form1_Load(object sender, EventArgs e) { }
@@ -51,16 +62,28 @@ namespace Anno1404Warenrechner
                 var needs = NeedsCalculator.CalculateNeeds(population);
 
                 this.RenderNeeds(needs);
+                labelError.Text = "";
             }
             catch (Exception exception)
             {
                 this.RenderNeeds(null);
 
-                MessageBox.Show(exception.Message, "Failed to load data.");
+                labelError.Text = "Failed to load data.";
             }
         }
 
-
-        
+        private void checkBoxPeriodicCheck_CheckedChanged(object sender, EventArgs e)
+        {
+            CheckBox cb = sender as CheckBox;
+            if (cb.Checked)
+            {
+                periodicCheckTimer.Start();
+                buttonLoadNeeds.PerformClick();
+            }
+            else
+            {
+                periodicCheckTimer.Stop();
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello! I really like your program and the fact that you are developing it open source! I was looking for a solution to continuously monitor my population needs without having to Alt-Tab out of my game. Especially in Coop-Multiplayer games, that is quite annoying because it pauses the game for all other players. With my small additions, I can run your tool on my second monitor and always get "live" updates on my populations needs. I hope you agree and find the time to review and merge this commit.

Cheers Jules

- Added Checkbox to trigger periodic (1min) check of the population needs.
- Enabling the checkbox performs an initial calculation of the needs and repeats that every minute.
- Manual calculations of the population needs can be performed at any time.
- Changed Error-Message from MessageBox to a label, so the program can be left running in the background without Messageboxes appearing regularly